### PR TITLE
refactor: use alpine mainline wireguard

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,6 @@
-FROM ubuntu:18.04
+FROM alpine:3.12.0
 
-RUN apt-get update -qq \
-  && apt-get install -y -qq software-properties-common \
-  && add-apt-repository ppa:wireguard/wireguard \
-  && apt-get update -qq \
-  && apt-get install -y -qq wireguard libmnl-dev libelf-dev build-essential pkg-config wget iproute2 net-tools \
-  && wget -O /wireguard.tar.xz https://git.zx2c4.com/WireGuard/snapshot/WireGuard-0.0.20190702.tar.xz \
-  && cd / \
-  && tar -xf /wireguard.tar.xz
+RUN apk add --no-cache -U wireguard-tools
 
 COPY entrypoint.sh /
 COPY start.sh /


### PR DESCRIPTION
Hey @vitobotta thanks for the Post which lead me here. Wireguard is in alpine now, 12mb built image compared to 470mb. I'm actively using this alpine image in a few rancher hosts. 

Saw you may not be using this image as much but for any one else visiting this may be usefull.